### PR TITLE
feat(bot): workflows to comment blog preview link

### DIFF
--- a/.github/workflows/preview-link.yml
+++ b/.github/workflows/preview-link.yml
@@ -21,41 +21,61 @@ jobs:
         run: |
           # Get changed files, handle potential errors
           CHANGED_FILES=$(git diff --name-only ${{ github.event.pull_request.base.sha }} ${{ github.event.pull_request.head.sha }} 2>/dev/null || echo "")
-
+          
           if [ -z "$CHANGED_FILES" ]; then
             echo "message=No blog content changes detected!" >> $GITHUB_OUTPUT
             exit 0
           fi
-
-          # Look for new blog folders or changes in _blog.yml
-          if echo "$CHANGED_FILES" | grep -q "^blogs/.*/content.md$"; then
-            # Extract folder name from changed content.md
-            SLUG=$(echo "$CHANGED_FILES" | grep "^blogs/.*/content.md$" | head -n 1 | cut -d'/' -f2)
-            if [ -n "$SLUG" ]; then
-              echo "slug=$SLUG" >> $GITHUB_OUTPUT
-              # Check if this is a new blog or edit
+          
+          # Initialize arrays for new and edited blogs
+          NEW_BLOGS=()
+          EDITED_BLOGS=()
+          
+          # Look for changes in blog folders
+          while IFS= read -r file; do
+            if [[ $file =~ ^blogs/([^/]+)/content\.md$ ]]; then
+              SLUG="${BASH_REMATCH[1]}"
               if git ls-tree -r --name-only ${{ github.event.pull_request.base.sha }} | grep -q "^blogs/$SLUG/"; then
-                echo "message=Edits in existing blog detected: \`$SLUG\`" >> $GITHUB_OUTPUT
+                EDITED_BLOGS+=("$SLUG")
               else
-                echo "message=New blog detected: \`$SLUG\`" >> $GITHUB_OUTPUT
+                NEW_BLOGS+=("$SLUG")
               fi
-            else
-              echo "message=No blog content changes detected!" >> $GITHUB_OUTPUT
             fi
-          elif echo "$CHANGED_FILES" | grep -q "^_blog.yml$"; then
-            # If _blog.yml changed, get the last added/modified blog slug
-            SLUG=$(git diff ${{ github.event.pull_request.base.sha }} ${{ github.event.pull_request.head.sha }} _blog.yml 2>/dev/null | grep -A 5 "slug:" | grep "slug:" | tail -n 1 | cut -d'"' -f2)
-            if [ -n "$SLUG" ]; then
-              echo "slug=$SLUG" >> $GITHUB_OUTPUT
-              # Check if this is a new blog or edit
-              if git ls-tree -r --name-only ${{ github.event.pull_request.base.sha }} | grep -q "^blogs/$SLUG/"; then
-                echo "message=Edits in existing blog detected: \`$SLUG\`" >> $GITHUB_OUTPUT
-              else
-                echo "message=New blog detected: \`$SLUG\`" >> $GITHUB_OUTPUT
+          done <<< "$CHANGED_FILES"
+          
+          # Look for changes in _blog.yml
+          if echo "$CHANGED_FILES" | grep -q "^_blog.yml$"; then
+            # Get all slugs from _blog.yml changes
+            while IFS= read -r slug; do
+              if [ -n "$slug" ]; then
+                if git ls-tree -r --name-only ${{ github.event.pull_request.base.sha }} | grep -q "^blogs/$slug/"; then
+                  EDITED_BLOGS+=("$slug")
+                else
+                  NEW_BLOGS+=("$slug")
+                fi
               fi
-            else
-              echo "message=No blog content changes detected!" >> $GITHUB_OUTPUT
-            fi
+            done < <(git diff ${{ github.event.pull_request.base.sha }} ${{ github.event.pull_request.head.sha }} _blog.yml 2>/dev/null | grep -A 5 "slug:" | grep "slug:" | cut -d'"' -f2)
+          fi
+          
+          # Remove duplicates and sort
+          NEW_BLOGS=($(printf "%s\n" "${NEW_BLOGS[@]}" | sort -u))
+          EDITED_BLOGS=($(printf "%s\n" "${EDITED_BLOGS[@]}" | sort -u))
+          
+          # Prepare message based on changes
+          if [ ${#NEW_BLOGS[@]} -gt 0 ] && [ ${#EDITED_BLOGS[@]} -gt 0 ]; then
+            # Join arrays with comma and space
+            NEW_BLOGS_STR=$(printf ",\`%s\`" "${NEW_BLOGS[@]}" | cut -c2-)
+            EDITED_BLOGS_STR=$(printf ",\`%s\`" "${EDITED_BLOGS[@]}" | cut -c2-)
+            echo "message=Multiple changes detected:\n\nNew blogs: ${NEW_BLOGS_STR}\n\nEdits in: ${EDITED_BLOGS_STR}" >> $GITHUB_OUTPUT
+            echo "slugs=${NEW_BLOGS[*]}" >> $GITHUB_OUTPUT
+          elif [ ${#NEW_BLOGS[@]} -gt 0 ]; then
+            NEW_BLOGS_STR=$(printf ",\`%s\`" "${NEW_BLOGS[@]}" | cut -c2-)
+            echo "message=New blogs detected: ${NEW_BLOGS_STR}" >> $GITHUB_OUTPUT
+            echo "slugs=${NEW_BLOGS[*]}" >> $GITHUB_OUTPUT
+          elif [ ${#EDITED_BLOGS[@]} -gt 0 ]; then
+            EDITED_BLOGS_STR=$(printf ",\`%s\`" "${EDITED_BLOGS[@]}" | cut -c2-)
+            echo "message=Edits in existing blogs detected: ${EDITED_BLOGS_STR}" >> $GITHUB_OUTPUT
+            echo "slugs=${EDITED_BLOGS[*]}" >> $GITHUB_OUTPUT
           else
             echo "message=No blog content changes detected!" >> $GITHUB_OUTPUT
           fi
@@ -70,12 +90,13 @@ jobs:
               repo: context.repo.repo,
               issue_number: context.issue.number,
             });
-
+            
+            // Delete all comments from the bot that contain "Preview Blog"
             const previewComments = comments.filter(comment => 
-              comment.body.includes('Preview Blog') && 
-              comment.user.login === 'github-actions[bot]'
+              comment.user.login === 'github-actions[bot]' && 
+              comment.body.includes('Preview Blog')
             );
-
+            
             for (const comment of previewComments) {
               await github.rest.issues.deleteComment({
                 owner: context.repo.owner,
@@ -90,28 +111,33 @@ jobs:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           script: |
             const message = '${{ steps.find-slug.outputs.message }}';
-            const slug = '${{ steps.find-slug.outputs.slug }}';
+            const slugs = '${{ steps.find-slug.outputs.slugs }}'.split(' ');
             const branch = context.payload.pull_request.head.ref;
             const owner = context.payload.pull_request.head.repo.owner.login;
             const repo = context.payload.pull_request.head.repo.name;
-
+            
             const blogListUrl = `https://www.binapani.com/draft/blog?preview=${branch}&owner=${owner}&repo=${repo}`;
-            const blogContentUrl = slug ? `https://www.binapani.com/draft/blog/${slug}?preview=${branch}&owner=${owner}&repo=${repo}` : '';
-
+            
             let body = `## 👀 Preview Blog\n\n${message}\n\n`;
-
-            if (!slug) {
+            
+            if (!slugs[0]) {
               body += `🔍 Please check the [guidelines](https://github.com/binapani-edu/blog/blob/main/README.md) for instructions on how to add your blog.\n\n`;
             } else {
               body += `## 🔍 Preview Links\n\n`;
               body += `📚 [Blog List Preview](${blogListUrl}) - your blog card in the list of all blogs\n`;
-              body += `📝 [Blog Content Preview](${blogContentUrl}) - your main blog content\n\n`;
+              
+              // Create content preview links for each blog
+              const contentLinks = slugs.map(slug => 
+                `[${slug}](${`https://www.binapani.com/draft/blog/${slug}?preview=${branch}&owner=${owner}&repo=${repo}`})`
+              ).join(', ');
+              
+              body += `📝 Blog Content Preview: ${contentLinks}\n\n`;
               body += `These links will be updated automatically when you push new changes.\n\n`;
             }
-
+            
             body += ` ---\n\n`;
             body += `Useful Links | [Binapani Blog](https://www.binapani.com/blog) | [Binapani Blog Preview Tool](https://www.binapani.com/draft/blog)`;
-
+            
             await github.rest.issues.createComment({
               owner: context.repo.owner,
               repo: context.repo.repo,

--- a/.github/workflows/preview-link.yml
+++ b/.github/workflows/preview-link.yml
@@ -16,10 +16,10 @@ jobs:
         with:
           fetch-depth: 0
 
-      - name: Find blog slug
+      - name: Validate and find blog slugs
         id: find-slug
         run: |
-          # Get changed files, handle potential errors
+          # Get changed files
           CHANGED_FILES=$(git diff --name-only ${{ github.event.pull_request.base.sha }} ${{ github.event.pull_request.head.sha }} 2>/dev/null || echo "")
           
           if [ -z "$CHANGED_FILES" ]; then
@@ -27,46 +27,67 @@ jobs:
             exit 0
           fi
           
-          # Initialize arrays for new and edited blogs
-          NEW_BLOGS=()
-          EDITED_BLOGS=()
+          # Step 1: Detect slugs from both sources
+          YAML_SLUGS=()
+          FOLDER_SLUGS=()
           
-          # Look for changes in blog folders
-          while IFS= read -r file; do
-            if [[ $file =~ ^blogs/([^/]+)/content\.md$ ]]; then
-              SLUG="${BASH_REMATCH[1]}"
-              if git ls-tree -r --name-only ${{ github.event.pull_request.base.sha }} | grep -q "^blogs/$SLUG/"; then
-                EDITED_BLOGS+=("$SLUG")
-              else
-                NEW_BLOGS+=("$SLUG")
-              fi
-            fi
-          done <<< "$CHANGED_FILES"
-          
-          # Look for changes in _blog.yml
+          # Detect slugs from _blog.yml changes
           if echo "$CHANGED_FILES" | grep -q "^_blog.yml$"; then
-            # Get all slugs from _blog.yml changes using a more precise pattern
             while IFS= read -r line; do
               if [[ $line =~ ^[[:space:]]*-[[:space:]]*slug:[[:space:]]*[\"']?([^\"']+)[\"']?$ ]]; then
-                SLUG="${BASH_REMATCH[1]}"
-                if [ -n "$SLUG" ]; then
-                  if git ls-tree -r --name-only ${{ github.event.pull_request.base.sha }} | grep -q "^blogs/$SLUG/"; then
-                    EDITED_BLOGS+=("$SLUG")
-                  else
-                    NEW_BLOGS+=("$SLUG")
-                  fi
-                fi
+                YAML_SLUGS+=("${BASH_REMATCH[1]}")
               fi
             done < <(git diff ${{ github.event.pull_request.base.sha }} ${{ github.event.pull_request.head.sha }} _blog.yml 2>/dev/null)
           fi
           
+          # Detect slugs from folder changes
+          while IFS= read -r file; do
+            if [[ $file =~ ^blogs/([^/]+)/content\.md$ ]]; then
+              FOLDER_SLUGS+=("${BASH_REMATCH[1]}")
+            fi
+          done <<< "$CHANGED_FILES"
+          
           # Remove duplicates and sort
-          NEW_BLOGS=($(printf "%s\n" "${NEW_BLOGS[@]}" | sort -u))
-          EDITED_BLOGS=($(printf "%s\n" "${EDITED_BLOGS[@]}" | sort -u))
+          YAML_SLUGS=($(printf "%s\n" "${YAML_SLUGS[@]}" | sort -u))
+          FOLDER_SLUGS=($(printf "%s\n" "${FOLDER_SLUGS[@]}" | sort -u))
+          
+          # Step 2: Validate slug consistency
+          if [ ${#YAML_SLUGS[@]} -ne ${#FOLDER_SLUGS[@]} ]; then
+            echo "error=true" >> $GITHUB_OUTPUT
+            echo "message=❌ Validation Error: Number of slugs in _blog.yml (${#YAML_SLUGS[@]}) doesn't match number of blog folders (${#FOLDER_SLUGS[@]})" >> $GITHUB_OUTPUT
+            exit 1
+          fi
+          
+          # Check if all slugs match
+          for yaml_slug in "${YAML_SLUGS[@]}"; do
+            found=false
+            for folder_slug in "${FOLDER_SLUGS[@]}"; do
+              if [ "$yaml_slug" = "$folder_slug" ]; then
+                found=true
+                break
+              fi
+            done
+            if [ "$found" = false ]; then
+              echo "error=true" >> $GITHUB_OUTPUT
+              echo "message=❌ Validation Error: Slug mismatch found. The slug in _blog.yml must exactly match the folder name in blogs/ directory.\n\nFound in _blog.yml: \`${YAML_SLUGS[*]}\`\nFound in blogs/: \`${FOLDER_SLUGS[*]}\`" >> $GITHUB_OUTPUT
+              exit 1
+            fi
+          done
+          
+          # Step 3: Determine if blogs are new or edited
+          NEW_BLOGS=()
+          EDITED_BLOGS=()
+          
+          for slug in "${YAML_SLUGS[@]}"; do
+            if git ls-tree -r --name-only ${{ github.event.pull_request.base.sha }} | grep -q "^blogs/$slug/"; then
+              EDITED_BLOGS+=("$slug")
+            else
+              NEW_BLOGS+=("$slug")
+            fi
+          done
           
           # Prepare message based on changes
           if [ ${#NEW_BLOGS[@]} -gt 0 ] && [ ${#EDITED_BLOGS[@]} -gt 0 ]; then
-            # Join arrays with comma and space
             NEW_BLOGS_STR=$(printf ",\`%s\`" "${NEW_BLOGS[@]}" | cut -c2-)
             EDITED_BLOGS_STR=$(printf ",\`%s\`" "${EDITED_BLOGS[@]}" | cut -c2-)
             echo "message=Multiple changes detected:\n\nNew blogs: ${NEW_BLOGS_STR}\n\nEdits in: ${EDITED_BLOGS_STR}" >> $GITHUB_OUTPUT
@@ -84,6 +105,7 @@ jobs:
           fi
 
       - name: Delete old preview comments
+        if: steps.find-slug.outputs.error != 'true'
         uses: actions/github-script@v7
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
@@ -109,6 +131,7 @@ jobs:
             }
 
       - name: Comment preview link or status
+        if: steps.find-slug.outputs.error != 'true'
         uses: actions/github-script@v7
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
@@ -140,6 +163,28 @@ jobs:
             
             body += ` ---\n\n`;
             body += `Useful Links | [Binapani Blog](https://www.binapani.com/blog) | [Binapani Blog Preview Tool](https://www.binapani.com/draft/blog)`;
+            
+            await github.rest.issues.createComment({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: context.issue.number,
+              body: body
+            });
+
+      - name: Comment validation error
+        if: steps.find-slug.outputs.error == 'true'
+        uses: actions/github-script@v7
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          script: |
+            const message = '${{ steps.find-slug.outputs.message }}';
+            
+            let body = `## ❌ Blog Validation Failed\n\n${message}\n\n`;
+            body += `Please ensure that:\n`;
+            body += `1. The slug in _blog.yml exactly matches the folder name in blogs/ directory\n`;
+            body += `2. Each blog has both a folder in blogs/ and an entry in _blog.yml\n`;
+            body += `3. The folder name and slug are in kebab-case (lowercase with hyphens)\n\n`;
+            body += `Check the [contribution guidelines](https://github.com/binapani-edu/blog/blob/main/README.md) for more details.`;
             
             await github.rest.issues.createComment({
               owner: context.repo.owner,

--- a/.github/workflows/preview-link.yml
+++ b/.github/workflows/preview-link.yml
@@ -30,59 +30,85 @@ jobs:
           # Step 1: Detect slugs from both sources
           YAML_SLUGS=()
           FOLDER_SLUGS=()
+          CHANGED_SLUGS=()  # Track which slugs were actually changed
           
           # Detect slugs from _blog.yml changes
           if echo "$CHANGED_FILES" | grep -q "^_blog.yml$"; then
+            # Get the diff of _blog.yml
+            YAML_DIFF=$(git diff ${{ github.event.pull_request.base.sha }} ${{ github.event.pull_request.head.sha }} _blog.yml 2>/dev/null)
+            
+            # Extract slugs from the diff
             while IFS= read -r line; do
               if [[ $line =~ ^[[:space:]]*-[[:space:]]*slug:[[:space:]]*[\"']?([^\"']+)[\"']?$ ]]; then
-                YAML_SLUGS+=("${BASH_REMATCH[1]}")
+                SLUG="${BASH_REMATCH[1]}"
+                YAML_SLUGS+=("$SLUG")
+                CHANGED_SLUGS+=("$SLUG")
               fi
-            done < <(git diff ${{ github.event.pull_request.base.sha }} ${{ github.event.pull_request.head.sha }} _blog.yml 2>/dev/null)
+            done <<< "$YAML_DIFF"
           fi
           
           # Detect slugs from folder changes
           while IFS= read -r file; do
             if [[ $file =~ ^blogs/([^/]+)/content\.md$ ]]; then
-              FOLDER_SLUGS+=("${BASH_REMATCH[1]}")
+              SLUG="${BASH_REMATCH[1]}"
+              FOLDER_SLUGS+=("$SLUG")
+              # Only add to CHANGED_SLUGS if not already there
+              if [[ ! " ${CHANGED_SLUGS[@]} " =~ " ${SLUG} " ]]; then
+                CHANGED_SLUGS+=("$SLUG")
+              fi
             fi
           done <<< "$CHANGED_FILES"
           
           # Remove duplicates and sort
           YAML_SLUGS=($(printf "%s\n" "${YAML_SLUGS[@]}" | sort -u))
           FOLDER_SLUGS=($(printf "%s\n" "${FOLDER_SLUGS[@]}" | sort -u))
+          CHANGED_SLUGS=($(printf "%s\n" "${CHANGED_SLUGS[@]}" | sort -u))
           
-          # Step 2: Validate slug consistency
-          if [ ${#YAML_SLUGS[@]} -ne ${#FOLDER_SLUGS[@]} ]; then
-            echo "error=true" >> $GITHUB_OUTPUT
-            echo "message=❌ Validation Error: Number of slugs in _blog.yml (${#YAML_SLUGS[@]}) doesn't match number of blog folders (${#FOLDER_SLUGS[@]})" >> $GITHUB_OUTPUT
-            exit 1
-          fi
-          
-          # Check if all slugs match
-          for yaml_slug in "${YAML_SLUGS[@]}"; do
-            found=false
-            for folder_slug in "${FOLDER_SLUGS[@]}"; do
-              if [ "$yaml_slug" = "$folder_slug" ]; then
-                found=true
+          # Step 2: Validate slug consistency for changed blogs only
+          for changed_slug in "${CHANGED_SLUGS[@]}"; do
+            # Check if slug exists in both YAML and folder
+            yaml_exists=false
+            folder_exists=false
+            
+            for yaml_slug in "${YAML_SLUGS[@]}"; do
+              if [ "$yaml_slug" = "$changed_slug" ]; then
+                yaml_exists=true
                 break
               fi
             done
-            if [ "$found" = false ]; then
+            
+            for folder_slug in "${FOLDER_SLUGS[@]}"; do
+              if [ "$folder_slug" = "$changed_slug" ]; then
+                folder_exists=true
+                break
+              fi
+            done
+            
+            if [ "$yaml_exists" = false ] || [ "$folder_exists" = false ]; then
               echo "error=true" >> $GITHUB_OUTPUT
-              echo "message=❌ Validation Error: Slug mismatch found. The slug in _blog.yml must exactly match the folder name in blogs/ directory.\n\nFound in _blog.yml: \`${YAML_SLUGS[*]}\`\nFound in blogs/: \`${FOLDER_SLUGS[*]}\`" >> $GITHUB_OUTPUT
+              echo "message=❌ Validation Error: Blog \`$changed_slug\` is missing in " >> $GITHUB_OUTPUT
+              if [ "$yaml_exists" = false ]; then
+                echo "message=${message}_blog.yml" >> $GITHUB_OUTPUT
+              fi
+              if [ "$folder_exists" = false ]; then
+                if [ "$yaml_exists" = false ]; then
+                  echo "message=${message} and " >> $GITHUB_OUTPUT
+                fi
+                echo "message=${message}blogs/ directory" >> $GITHUB_OUTPUT
+              fi
               exit 1
             fi
           done
           
-          # Step 3: Determine if blogs are new or edited
+          # Step 3: Determine if changed blogs are new or edited
           NEW_BLOGS=()
           EDITED_BLOGS=()
           
-          for slug in "${YAML_SLUGS[@]}"; do
-            if git ls-tree -r --name-only ${{ github.event.pull_request.base.sha }} | grep -q "^blogs/$slug/"; then
-              EDITED_BLOGS+=("$slug")
+          for changed_slug in "${CHANGED_SLUGS[@]}"; do
+            if git ls-tree -r --name-only ${{ github.event.pull_request.base.sha }} | grep -q "^blogs/$changed_slug/"; then
+              EDITED_BLOGS+=("$changed_slug")
             else
-              NEW_BLOGS+=("$slug")
+              NEW_BLOGS+=("$changed_slug")
             fi
           done
           

--- a/.github/workflows/preview-link.yml
+++ b/.github/workflows/preview-link.yml
@@ -1,0 +1,80 @@
+name: Blog Preview Link Commenter
+
+on:
+  pull_request:
+    types: [opened, synchronize, reopened]
+
+jobs:
+  comment-preview:
+    runs-on: ubuntu-latest
+    permissions:
+      pull-requests: write
+      contents: read
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Find blog slug
+        id: find-slug
+        run: |
+          # Get changed files
+          CHANGED_FILES=$(git diff --name-only ${{ github.event.pull_request.base.sha }} ${{ github.event.pull_request.head.sha }})
+          
+          # Look for new blog folders or changes in _blog.yml
+          if echo "$CHANGED_FILES" | grep -q "^blogs/.*/content.md$"; then
+            # Extract folder name from changed content.md
+            SLUG=$(echo "$CHANGED_FILES" | grep "^blogs/.*/content.md$" | head -n 1 | cut -d'/' -f2)
+            echo "slug=$SLUG" >> $GITHUB_OUTPUT
+          elif echo "$CHANGED_FILES" | grep -q "^_blog.yml$"; then
+            # If _blog.yml changed, get the last added/modified blog slug
+            SLUG=$(git diff ${{ github.event.pull_request.base.sha }} ${{ github.event.pull_request.head.sha }} _blog.yml | grep -A 5 "slug:" | grep "slug:" | tail -n 1 | cut -d'"' -f2)
+            echo "slug=$SLUG" >> $GITHUB_OUTPUT
+          else
+            echo "No blog content changes found"
+            exit 0
+          fi
+
+      - name: Delete old preview comments
+        uses: actions/github-script@v7
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          script: |
+            const { data: comments } = await github.rest.issues.listComments({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: context.issue.number,
+            });
+            
+            const previewComments = comments.filter(comment => 
+              comment.body.includes('Blog Preview Link') && 
+              comment.user.login === 'github-actions[bot]'
+            );
+            
+            for (const comment of previewComments) {
+              await github.rest.issues.deleteComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                comment_id: comment.id,
+              });
+            }
+
+      - name: Comment preview link
+        uses: actions/github-script@v7
+        if: steps.find-slug.outputs.slug != ''
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          script: |
+            const baseUrl = 'https://binapani.com/draft/blog';
+            const branch = context.payload.pull_request.head.ref;
+            const owner = context.payload.pull_request.head.repo.owner.login;
+            const repo = context.payload.pull_request.head.repo.name;
+            const slug = '${{ steps.find-slug.outputs.slug }}';
+            
+            const previewUrl = `${baseUrl}/${slug}?preview=${branch}&owner=${owner}&repo=${repo}`;
+            
+            await github.rest.issues.createComment({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: context.issue.number,
+              body: `## Blog Preview Link\n\nYou can preview your blog post here:\n\n${previewUrl}\n\nThis link will be updated automatically when you push new changes.`
+            }); 

--- a/.github/workflows/preview-link.yml
+++ b/.github/workflows/preview-link.yml
@@ -14,19 +14,19 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v4
         with:
-          fetch-depth: 0  # Fetch all history for proper diff
+          fetch-depth: 0
 
       - name: Find blog slug
         id: find-slug
         run: |
           # Get changed files, handle potential errors
           CHANGED_FILES=$(git diff --name-only ${{ github.event.pull_request.base.sha }} ${{ github.event.pull_request.head.sha }} 2>/dev/null || echo "")
-          
+
           if [ -z "$CHANGED_FILES" ]; then
-            echo "message=No blog content changes detected. Please check the [contribution guidelines](https://github.com/binapani-edu/blog/blob/main/README.md) for instructions on how to add your blog." >> $GITHUB_OUTPUT
+            echo "message=No blog content changes detected!" >> $GITHUB_OUTPUT
             exit 0
           fi
-          
+
           # Look for new blog folders or changes in _blog.yml
           if echo "$CHANGED_FILES" | grep -q "^blogs/.*/content.md$"; then
             # Extract folder name from changed content.md
@@ -35,12 +35,12 @@ jobs:
               echo "slug=$SLUG" >> $GITHUB_OUTPUT
               # Check if this is a new blog or edit
               if git ls-tree -r --name-only ${{ github.event.pull_request.base.sha }} | grep -q "^blogs/$SLUG/"; then
-                echo "message=Changes detected in blog: \`$SLUG\`. You can preview your edits below." >> $GITHUB_OUTPUT
+                echo "message=Edits in existing blog detected: \`$SLUG\`" >> $GITHUB_OUTPUT
               else
-                echo "message=New blog detected: \`$SLUG\`. You can preview your blog below." >> $GITHUB_OUTPUT
+                echo "message=New blog detected: \`$SLUG\`" >> $GITHUB_OUTPUT
               fi
             else
-              echo "message=No blog content changes detected. Please check the [contribution guidelines](https://github.com/binapani-edu/blog/blob/main/README.md) for instructions on how to add your blog." >> $GITHUB_OUTPUT
+              echo "message=No blog content changes detected!" >> $GITHUB_OUTPUT
             fi
           elif echo "$CHANGED_FILES" | grep -q "^_blog.yml$"; then
             # If _blog.yml changed, get the last added/modified blog slug
@@ -49,15 +49,15 @@ jobs:
               echo "slug=$SLUG" >> $GITHUB_OUTPUT
               # Check if this is a new blog or edit
               if git ls-tree -r --name-only ${{ github.event.pull_request.base.sha }} | grep -q "^blogs/$SLUG/"; then
-                echo "message=Changes detected in blog: \`$SLUG\`. You can preview your edits below." >> $GITHUB_OUTPUT
+                echo "message=Edits in existing blog detected: \`$SLUG\`" >> $GITHUB_OUTPUT
               else
-                echo "message=New blog detected: \`$SLUG\`. You can preview your blog below." >> $GITHUB_OUTPUT
+                echo "message=New blog detected: \`$SLUG\`" >> $GITHUB_OUTPUT
               fi
             else
-              echo "message=No blog content changes detected. Please check the [contribution guidelines](https://github.com/binapani-edu/blog/blob/main/README.md) for instructions on how to add your blog." >> $GITHUB_OUTPUT
+              echo "message=No blog content changes detected!" >> $GITHUB_OUTPUT
             fi
           else
-            echo "message=No blog content changes detected. Please check the [contribution guidelines](https://github.com/binapani-edu/blog/blob/main/README.md) for instructions on how to add your blog." >> $GITHUB_OUTPUT
+            echo "message=No blog content changes detected!" >> $GITHUB_OUTPUT
           fi
 
       - name: Delete old preview comments
@@ -70,12 +70,12 @@ jobs:
               repo: context.repo.repo,
               issue_number: context.issue.number,
             });
-            
+
             const previewComments = comments.filter(comment => 
               comment.body.includes('Preview Blog') && 
               comment.user.login === 'github-actions[bot]'
             );
-            
+
             for (const comment of previewComments) {
               await github.rest.issues.deleteComment({
                 owner: context.repo.owner,
@@ -94,26 +94,27 @@ jobs:
             const branch = context.payload.pull_request.head.ref;
             const owner = context.payload.pull_request.head.repo.owner.login;
             const repo = context.payload.pull_request.head.repo.name;
-            
-            const draftBaseUrl = 'https://www.binapani.com/draft/blog';
-            const blogListUrl = `${draftBaseUrl}?preview=${branch}&owner=${owner}&repo=${repo}`;
-            const blogContentUrl = slug ? `${draftBaseUrl}/${slug}?preview=${branch}&owner=${owner}&repo=${repo}` : '';
-            
-            let body = `## Preview Blog\n\n${message}\n\n`;
-            
+
+            const blogListUrl = `https://www.binapani.com/draft/blog?preview=${branch}&owner=${owner}&repo=${repo}`;
+            const blogContentUrl = slug ? `https://www.binapani.com/draft/blog/${slug}?preview=${branch}&owner=${owner}&repo=${repo}` : '';
+
+            let body = `## 👀 Preview Blog\n\n${message}\n\n`;
+
             if (!slug) {
-              body += `Visit [Binapani Blog Preview](${draftBaseUrl}) to see how your changes will look like.`;
+              body += `🔍 Please check the [guidelines](https://github.com/binapani-edu/blog/blob/main/README.md) for instructions on how to add your blog.\n\n`;
             } else {
-              body += `### Preview Links\n\n`;
-              body += `- [Binapani Blog Preview](${draftBaseUrl}) - See how your changes will look like\n`;
-              body += `- [Blog List Preview](${blogListUrl}) - Preview your blog in the list\n`;
-              body += `- [Blog Content Preview](${blogContentUrl}) - Preview your blog content\n\n`;
-              body += `These links will be updated automatically when you push new changes.`;
+              body += `## 🔍 Preview Links\n\n`;
+              body += `📚 [Blog List Preview](${blogListUrl}) - your blog card in the list of all blogs\n`;
+              body += `📝 [Blog Content Preview](${blogContentUrl}) - your main blog content\n\n`;
+              body += `These links will be updated automatically when you push new changes.\n\n`;
             }
-            
+
+            body += ` ---\n\n`;
+            body += `Useful Links | [Binapani Blog](https://www.binapani.com/blog) | [Binapani Blog Preview Tool](https://www.binapani.com/draft/blog)`;
+
             await github.rest.issues.createComment({
               owner: context.repo.owner,
               repo: context.repo.repo,
               issue_number: context.issue.number,
               body: body
-            }); 
+            });

--- a/.github/workflows/preview-link.yml
+++ b/.github/workflows/preview-link.yml
@@ -16,122 +16,101 @@ jobs:
         with:
           fetch-depth: 0
 
-      - name: Validate and find blog slugs
-        id: find-slug
+      - name: Detect blog changes
+        id: detect-changes
         run: |
+          # Get list of slugs from main branch _blog.yml
+          git show ${{ github.event.pull_request.base.sha }}:_blog.yml > main_blog.yml 2>/dev/null || echo "" > main_blog.yml
+          
+          # Extract all slugs from main branch
+          MAIN_SLUGS=()
+          while IFS= read -r line; do
+            if [[ $line =~ ^[[:space:]]*-[[:space:]]*slug:[[:space:]]*[\"']?([^\"']+)[\"']?$ ]]; then
+              MAIN_SLUGS+=("${BASH_REMATCH[1]}")
+            fi
+          done < main_blog.yml
+          
+          # Extract all slugs from current _blog.yml
+          CURRENT_SLUGS=()
+          while IFS= read -r line; do
+            if [[ $line =~ ^[[:space:]]*-[[:space:]]*slug:[[:space:]]*[\"']?([^\"']+)[\"']?$ ]]; then
+              CURRENT_SLUGS+=("${BASH_REMATCH[1]}")
+            fi
+          done < _blog.yml
+          
+          # Find new and edited slugs
+          NEW_SLUGS=()
+          
+          for slug in "${CURRENT_SLUGS[@]}"; do
+            if ! echo "${MAIN_SLUGS[@]}" | grep -q "$slug"; then
+              NEW_SLUGS+=("$slug")
+            fi
+          done
+          
+          # Check for content changes in existing blogs
+          EDITED_SLUGS=()
+          
           # Get changed files
-          CHANGED_FILES=$(git diff --name-only ${{ github.event.pull_request.base.sha }} ${{ github.event.pull_request.head.sha }} 2>/dev/null || echo "")
+          CHANGED_FILES=$(git diff --name-only ${{ github.event.pull_request.base.sha }} ${{ github.event.pull_request.head.sha }})
           
-          if [ -z "$CHANGED_FILES" ]; then
-            echo "message=No blog content changes detected!" >> $GITHUB_OUTPUT
-            exit 0
-          fi
+          for slug in "${CURRENT_SLUGS[@]}"; do
+            # Skip if it's a new slug
+            if echo "${NEW_SLUGS[@]}" | grep -q "$slug"; then
+              continue
+            fi
+            
+            # Check if content.md was changed
+            if echo "$CHANGED_FILES" | grep -q "^blogs/$slug/"; then
+              EDITED_SLUGS+=("$slug")
+            fi
+          done
           
-          # Step 1: Detect slugs from both sources
-          YAML_SLUGS=()
-          FOLDER_SLUGS=()
-          CHANGED_SLUGS=()  # Track which slugs were actually changed
-          
-          # Detect slugs from _blog.yml changes
+          # Also check if _blog.yml was modified for existing slugs
           if echo "$CHANGED_FILES" | grep -q "^_blog.yml$"; then
-            # Get the diff of _blog.yml
-            YAML_DIFF=$(git diff ${{ github.event.pull_request.base.sha }} ${{ github.event.pull_request.head.sha }} _blog.yml 2>/dev/null)
-            
-            # Extract slugs from the diff
-            while IFS= read -r line; do
-              if [[ $line =~ ^[[:space:]]*-[[:space:]]*slug:[[:space:]]*[\"']?([^\"']+)[\"']?$ ]]; then
-                SLUG="${BASH_REMATCH[1]}"
-                YAML_SLUGS+=("$SLUG")
-                CHANGED_SLUGS+=("$SLUG")
+            for slug in "${CURRENT_SLUGS[@]}"; do
+              # Skip if it's already in NEW_SLUGS or EDITED_SLUGS
+              if echo "${NEW_SLUGS[@]}" | grep -q "$slug" || echo "${EDITED_SLUGS[@]}" | grep -q "$slug"; then
+                continue
               fi
-            done <<< "$YAML_DIFF"
+              
+              # Check if this slug entry was modified in _blog.yml
+              if git diff ${{ github.event.pull_request.base.sha }} ${{ github.event.pull_request.head.sha }} _blog.yml | grep -q "slug: $slug"; then
+                EDITED_SLUGS+=("$slug")
+              fi
+            done
           fi
           
-          # Detect slugs from folder changes
-          while IFS= read -r file; do
-            if [[ $file =~ ^blogs/([^/]+)/content\.md$ ]]; then
-              SLUG="${BASH_REMATCH[1]}"
-              FOLDER_SLUGS+=("$SLUG")
-              # Only add to CHANGED_SLUGS if not already there
-              if [[ ! " ${CHANGED_SLUGS[@]} " =~ " ${SLUG} " ]]; then
-                CHANGED_SLUGS+=("$SLUG")
-              fi
-            fi
-          done <<< "$CHANGED_FILES"
+          # Remove duplicates
+          NEW_SLUGS=($(echo "${NEW_SLUGS[@]}" | tr ' ' '\n' | sort -u | tr '\n' ' '))
+          EDITED_SLUGS=($(echo "${EDITED_SLUGS[@]}" | tr ' ' '\n' | sort -u | tr '\n' ' '))
           
-          # Remove duplicates and sort
-          YAML_SLUGS=($(printf "%s\n" "${YAML_SLUGS[@]}" | sort -u))
-          FOLDER_SLUGS=($(printf "%s\n" "${FOLDER_SLUGS[@]}" | sort -u))
-          CHANGED_SLUGS=($(printf "%s\n" "${CHANGED_SLUGS[@]}" | sort -u))
+          # Format slugs for output
+          if [ ${#NEW_SLUGS[@]} -gt 0 ]; then
+            NEW_SLUGS_STR=$(printf ",\`%s\`" "${NEW_SLUGS[@]}" | cut -c2-)
+            echo "new_slugs=${NEW_SLUGS[*]}" >> $GITHUB_OUTPUT
+          fi
           
-          # Step 2: Validate slug consistency for changed blogs only
-          for changed_slug in "${CHANGED_SLUGS[@]}"; do
-            # Check if slug exists in both YAML and folder
-            yaml_exists=false
-            folder_exists=false
-            
-            for yaml_slug in "${YAML_SLUGS[@]}"; do
-              if [ "$yaml_slug" = "$changed_slug" ]; then
-                yaml_exists=true
-                break
-              fi
-            done
-            
-            for folder_slug in "${FOLDER_SLUGS[@]}"; do
-              if [ "$folder_slug" = "$changed_slug" ]; then
-                folder_exists=true
-                break
-              fi
-            done
-            
-            if [ "$yaml_exists" = false ] || [ "$folder_exists" = false ]; then
-              echo "error=true" >> $GITHUB_OUTPUT
-              echo "message=❌ Validation Error: Blog \`$changed_slug\` is missing in " >> $GITHUB_OUTPUT
-              if [ "$yaml_exists" = false ]; then
-                echo "message=${message}_blog.yml" >> $GITHUB_OUTPUT
-              fi
-              if [ "$folder_exists" = false ]; then
-                if [ "$yaml_exists" = false ]; then
-                  echo "message=${message} and " >> $GITHUB_OUTPUT
-                fi
-                echo "message=${message}blogs/ directory" >> $GITHUB_OUTPUT
-              fi
-              exit 1
-            fi
-          done
+          if [ ${#EDITED_SLUGS[@]} -gt 0 ]; then
+            EDITED_SLUGS_STR=$(printf ",\`%s\`" "${EDITED_SLUGS[@]}" | cut -c2-)
+            echo "edited_slugs=${EDITED_SLUGS[*]}" >> $GITHUB_OUTPUT
+          fi
           
-          # Step 3: Determine if changed blogs are new or edited
-          NEW_BLOGS=()
-          EDITED_BLOGS=()
-          
-          for changed_slug in "${CHANGED_SLUGS[@]}"; do
-            if git ls-tree -r --name-only ${{ github.event.pull_request.base.sha }} | grep -q "^blogs/$changed_slug/"; then
-              EDITED_BLOGS+=("$changed_slug")
-            else
-              NEW_BLOGS+=("$changed_slug")
-            fi
-          done
-          
-          # Prepare message based on changes
-          if [ ${#NEW_BLOGS[@]} -gt 0 ] && [ ${#EDITED_BLOGS[@]} -gt 0 ]; then
-            NEW_BLOGS_STR=$(printf ",\`%s\`" "${NEW_BLOGS[@]}" | cut -c2-)
-            EDITED_BLOGS_STR=$(printf ",\`%s\`" "${EDITED_BLOGS[@]}" | cut -c2-)
-            echo "message=Multiple changes detected:\n\nNew blogs: ${NEW_BLOGS_STR}\n\nEdits in: ${EDITED_BLOGS_STR}" >> $GITHUB_OUTPUT
-            echo "slugs=${NEW_BLOGS[*]}" >> $GITHUB_OUTPUT
-          elif [ ${#NEW_BLOGS[@]} -gt 0 ]; then
-            NEW_BLOGS_STR=$(printf ",\`%s\`" "${NEW_BLOGS[@]}" | cut -c2-)
-            echo "message=New blogs detected: ${NEW_BLOGS_STR}" >> $GITHUB_OUTPUT
-            echo "slugs=${NEW_BLOGS[*]}" >> $GITHUB_OUTPUT
-          elif [ ${#EDITED_BLOGS[@]} -gt 0 ]; then
-            EDITED_BLOGS_STR=$(printf ",\`%s\`" "${EDITED_BLOGS[@]}" | cut -c2-)
-            echo "message=Edits in existing blogs detected: ${EDITED_BLOGS_STR}" >> $GITHUB_OUTPUT
-            echo "slugs=${EDITED_BLOGS[*]}" >> $GITHUB_OUTPUT
+          # Determine message based on changes
+          if [ ${#NEW_SLUGS[@]} -gt 0 ] && [ ${#EDITED_SLUGS[@]} -gt 0 ]; then
+            echo "message=Multiple changes detected:\n\nNew blogs: ${NEW_SLUGS_STR}\n\nEdits in: ${EDITED_SLUGS_STR}" >> $GITHUB_OUTPUT
+            echo "has_changes=true" >> $GITHUB_OUTPUT
+          elif [ ${#NEW_SLUGS[@]} -gt 0 ]; then
+            echo "message=New blogs detected: ${NEW_SLUGS_STR}" >> $GITHUB_OUTPUT
+            echo "has_changes=true" >> $GITHUB_OUTPUT
+          elif [ ${#EDITED_SLUGS[@]} -gt 0 ]; then
+            echo "message=Edits in existing blogs detected: ${EDITED_SLUGS_STR}" >> $GITHUB_OUTPUT
+            echo "has_changes=true" >> $GITHUB_OUTPUT
           else
             echo "message=No blog content changes detected!" >> $GITHUB_OUTPUT
+            echo "has_changes=false" >> $GITHUB_OUTPUT
           fi
 
       - name: Delete old preview comments
-        if: steps.find-slug.outputs.error != 'true'
         uses: actions/github-script@v7
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
@@ -156,61 +135,52 @@ jobs:
               });
             }
 
-      - name: Comment preview link or status
-        if: steps.find-slug.outputs.error != 'true'
+      - name: Comment preview link
         uses: actions/github-script@v7
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           script: |
-            const message = '${{ steps.find-slug.outputs.message }}';
-            const slugs = '${{ steps.find-slug.outputs.slugs }}'.split(' ');
+            const message = '${{ steps.detect-changes.outputs.message }}';
+            const hasChanges = '${{ steps.detect-changes.outputs.has_changes }}' === 'true';
             const branch = context.payload.pull_request.head.ref;
             const owner = context.payload.pull_request.head.repo.owner.login;
             const repo = context.payload.pull_request.head.repo.name;
             
-            const blogListUrl = `https://www.binapani.com/draft/blog?preview=${branch}&owner=${owner}&repo=${repo}`;
-            
             let body = `## 👀 Preview Blog\n\n${message}\n\n`;
             
-            if (!slugs[0]) {
-              body += `🔍 Please check the [guidelines](https://github.com/binapani-edu/blog/blob/main/README.md) for instructions on how to add your blog.\n\n`;
-            } else {
+            if (hasChanges) {
+              const blogListUrl = `https://www.binapani.com/draft/blog?preview=${branch}&owner=${owner}&repo=${repo}`;
               body += `## 🔍 Preview Links\n\n`;
               body += `📚 [Blog List Preview](${blogListUrl}) - your blog card in the list of all blogs\n`;
               
               // Create content preview links for each blog
-              const contentLinks = slugs.map(slug => 
-                `[${slug}](${`https://www.binapani.com/draft/blog/${slug}?preview=${branch}&owner=${owner}&repo=${repo}`})`
-              ).join(', ');
+              let slugs = [];
               
-              body += `📝 Blog Content Preview: ${contentLinks}\n\n`;
+              const newSlugs = '${{ steps.detect-changes.outputs.new_slugs }}'.trim();
+              if (newSlugs) {
+                slugs = slugs.concat(newSlugs.split(' '));
+              }
+              
+              const editedSlugs = '${{ steps.detect-changes.outputs.edited_slugs }}'.trim();
+              if (editedSlugs && !newSlugs) {
+                slugs = slugs.concat(editedSlugs.split(' '));
+              }
+              
+              if (slugs.length > 0) {
+                const contentLinks = slugs.map(slug => 
+                  `[${slug}](${`https://www.binapani.com/draft/blog/${slug}?preview=${branch}&owner=${owner}&repo=${repo}`})`
+                ).join(', ');
+                
+                body += `📝 Blog Content Preview: ${contentLinks}\n\n`;
+              }
+              
               body += `These links will be updated automatically when you push new changes.\n\n`;
+            } else {
+              body += `🔍 Please check the [guidelines](https://github.com/binapani-edu/blog/blob/main/README.md) for instructions on how to add your blog.\n\n`;
             }
             
             body += ` ---\n\n`;
             body += `Useful Links | [Binapani Blog](https://www.binapani.com/blog) | [Binapani Blog Preview Tool](https://www.binapani.com/draft/blog)`;
-            
-            await github.rest.issues.createComment({
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              issue_number: context.issue.number,
-              body: body
-            });
-
-      - name: Comment validation error
-        if: steps.find-slug.outputs.error == 'true'
-        uses: actions/github-script@v7
-        with:
-          github-token: ${{ secrets.GITHUB_TOKEN }}
-          script: |
-            const message = '${{ steps.find-slug.outputs.message }}';
-            
-            let body = `## ❌ Blog Validation Failed\n\n${message}\n\n`;
-            body += `Please ensure that:\n`;
-            body += `1. The slug in _blog.yml exactly matches the folder name in blogs/ directory\n`;
-            body += `2. Each blog has both a folder in blogs/ and an entry in _blog.yml\n`;
-            body += `3. The folder name and slug are in kebab-case (lowercase with hyphens)\n\n`;
-            body += `Check the [contribution guidelines](https://github.com/binapani-edu/blog/blob/main/README.md) for more details.`;
             
             await github.rest.issues.createComment({
               owner: context.repo.owner,

--- a/.github/workflows/preview-link.yml
+++ b/.github/workflows/preview-link.yml
@@ -23,7 +23,7 @@ jobs:
           CHANGED_FILES=$(git diff --name-only ${{ github.event.pull_request.base.sha }} ${{ github.event.pull_request.head.sha }} 2>/dev/null || echo "")
           
           if [ -z "$CHANGED_FILES" ]; then
-            echo "message=No changes detected in blog content." >> $GITHUB_OUTPUT
+            echo "message=No blog content changes detected. Please check the [contribution guidelines](https://github.com/binapani-edu/blog/blob/main/README.md) for instructions on how to add your blog." >> $GITHUB_OUTPUT
             exit 0
           fi
           
@@ -35,12 +35,12 @@ jobs:
               echo "slug=$SLUG" >> $GITHUB_OUTPUT
               # Check if this is a new blog or edit
               if git ls-tree -r --name-only ${{ github.event.pull_request.base.sha }} | grep -q "^blogs/$SLUG/"; then
-                echo "message=Edit detected in blog: $SLUG" >> $GITHUB_OUTPUT
+                echo "message=Changes detected in blog: \`$SLUG\`. You can preview your edits below." >> $GITHUB_OUTPUT
               else
-                echo "message=New blog detected: $SLUG" >> $GITHUB_OUTPUT
+                echo "message=New blog detected: \`$SLUG\`. You can preview your blog below." >> $GITHUB_OUTPUT
               fi
             else
-              echo "message=No changes detected in blog content." >> $GITHUB_OUTPUT
+              echo "message=No blog content changes detected. Please check the [contribution guidelines](https://github.com/binapani-edu/blog/blob/main/README.md) for instructions on how to add your blog." >> $GITHUB_OUTPUT
             fi
           elif echo "$CHANGED_FILES" | grep -q "^_blog.yml$"; then
             # If _blog.yml changed, get the last added/modified blog slug
@@ -49,15 +49,15 @@ jobs:
               echo "slug=$SLUG" >> $GITHUB_OUTPUT
               # Check if this is a new blog or edit
               if git ls-tree -r --name-only ${{ github.event.pull_request.base.sha }} | grep -q "^blogs/$SLUG/"; then
-                echo "message=Edit detected in blog: $SLUG" >> $GITHUB_OUTPUT
+                echo "message=Changes detected in blog: \`$SLUG\`. You can preview your edits below." >> $GITHUB_OUTPUT
               else
-                echo "message=New blog detected: $SLUG" >> $GITHUB_OUTPUT
+                echo "message=New blog detected: \`$SLUG\`. You can preview your blog below." >> $GITHUB_OUTPUT
               fi
             else
-              echo "message=No changes detected in blog content." >> $GITHUB_OUTPUT
+              echo "message=No blog content changes detected. Please check the [contribution guidelines](https://github.com/binapani-edu/blog/blob/main/README.md) for instructions on how to add your blog." >> $GITHUB_OUTPUT
             fi
           else
-            echo "message=No changes detected in blog content." >> $GITHUB_OUTPUT
+            echo "message=No blog content changes detected. Please check the [contribution guidelines](https://github.com/binapani-edu/blog/blob/main/README.md) for instructions on how to add your blog." >> $GITHUB_OUTPUT
           fi
 
       - name: Delete old preview comments
@@ -72,7 +72,7 @@ jobs:
             });
             
             const previewComments = comments.filter(comment => 
-              comment.body.includes('Blog Preview') && 
+              comment.body.includes('Preview Blog') && 
               comment.user.login === 'github-actions[bot]'
             );
             
@@ -91,27 +91,29 @@ jobs:
           script: |
             const message = '${{ steps.find-slug.outputs.message }}';
             const slug = '${{ steps.find-slug.outputs.slug }}';
-            
-            if (!slug) {
-              await github.rest.issues.createComment({
-                owner: context.repo.owner,
-                repo: context.repo.repo,
-                issue_number: context.issue.number,
-                body: `## Blog Preview Status\n\n${message}`
-              });
-              return;
-            }
-            
-            const baseUrl = 'https://binapani.com/draft/blog';
             const branch = context.payload.pull_request.head.ref;
             const owner = context.payload.pull_request.head.repo.owner.login;
             const repo = context.payload.pull_request.head.repo.name;
             
-            const previewUrl = `${baseUrl}/${slug}?preview=${branch}&owner=${owner}&repo=${repo}`;
+            const draftBaseUrl = 'https://www.binapani.com/draft/blog';
+            const blogListUrl = `${draftBaseUrl}?preview=${branch}&owner=${owner}&repo=${repo}`;
+            const blogContentUrl = slug ? `${draftBaseUrl}/${slug}?preview=${branch}&owner=${owner}&repo=${repo}` : '';
+            
+            let body = `## Preview Blog\n\n${message}\n\n`;
+            
+            if (!slug) {
+              body += `Visit [Binapani Blog Preview](${draftBaseUrl}) to see how your changes will look like.`;
+            } else {
+              body += `### Preview Links\n\n`;
+              body += `- [Binapani Blog Preview](${draftBaseUrl}) - See how your changes will look like\n`;
+              body += `- [Blog List Preview](${blogListUrl}) - Preview your blog in the list\n`;
+              body += `- [Blog Content Preview](${blogContentUrl}) - Preview your blog content\n\n`;
+              body += `These links will be updated automatically when you push new changes.`;
+            }
             
             await github.rest.issues.createComment({
               owner: context.repo.owner,
               repo: context.repo.repo,
               issue_number: context.issue.number,
-              body: `## Blog Preview Link\n\n${message}\n\nYou can preview your blog post here:\n\n${previewUrl}\n\nThis link will be updated automatically when you push new changes.`
+              body: body
             }); 

--- a/.github/workflows/preview-link.yml
+++ b/.github/workflows/preview-link.yml
@@ -21,16 +21,16 @@ jobs:
         run: |
           # Get changed files, handle potential errors
           CHANGED_FILES=$(git diff --name-only ${{ github.event.pull_request.base.sha }} ${{ github.event.pull_request.head.sha }} 2>/dev/null || echo "")
-
+          
           if [ -z "$CHANGED_FILES" ]; then
             echo "message=No blog content changes detected!" >> $GITHUB_OUTPUT
             exit 0
           fi
-
+          
           # Initialize arrays for new and edited blogs
           NEW_BLOGS=()
           EDITED_BLOGS=()
-
+          
           # Look for changes in blog folders
           while IFS= read -r file; do
             if [[ $file =~ ^blogs/([^/]+)/content\.md$ ]]; then
@@ -42,25 +42,28 @@ jobs:
               fi
             fi
           done <<< "$CHANGED_FILES"
-
+          
           # Look for changes in _blog.yml
           if echo "$CHANGED_FILES" | grep -q "^_blog.yml$"; then
-            # Get all slugs from _blog.yml changes
-            while IFS= read -r slug; do
-              if [ -n "$slug" ]; then
-                if git ls-tree -r --name-only ${{ github.event.pull_request.base.sha }} | grep -q "^blogs/$slug/"; then
-                  EDITED_BLOGS+=("$slug")
-                else
-                  NEW_BLOGS+=("$slug")
+            # Get all slugs from _blog.yml changes using a more precise pattern
+            while IFS= read -r line; do
+              if [[ $line =~ ^[[:space:]]*-[[:space:]]*slug:[[:space:]]*[\"']?([^\"']+)[\"']?$ ]]; then
+                SLUG="${BASH_REMATCH[1]}"
+                if [ -n "$SLUG" ]; then
+                  if git ls-tree -r --name-only ${{ github.event.pull_request.base.sha }} | grep -q "^blogs/$SLUG/"; then
+                    EDITED_BLOGS+=("$SLUG")
+                  else
+                    NEW_BLOGS+=("$SLUG")
+                  fi
                 fi
               fi
-            done < <(git diff ${{ github.event.pull_request.base.sha }} ${{ github.event.pull_request.head.sha }} _blog.yml 2>/dev/null | grep -A 5 "slug:" | grep "slug:" | cut -d'"' -f2)
+            done < <(git diff ${{ github.event.pull_request.base.sha }} ${{ github.event.pull_request.head.sha }} _blog.yml 2>/dev/null)
           fi
-
+          
           # Remove duplicates and sort
           NEW_BLOGS=($(printf "%s\n" "${NEW_BLOGS[@]}" | sort -u))
           EDITED_BLOGS=($(printf "%s\n" "${EDITED_BLOGS[@]}" | sort -u))
-
+          
           # Prepare message based on changes
           if [ ${#NEW_BLOGS[@]} -gt 0 ] && [ ${#EDITED_BLOGS[@]} -gt 0 ]; then
             # Join arrays with comma and space
@@ -90,13 +93,13 @@ jobs:
               repo: context.repo.repo,
               issue_number: context.issue.number,
             });
-
+            
             // Delete all comments from the bot that contain "Preview Blog"
             const previewComments = comments.filter(comment => 
               comment.user.login === 'github-actions[bot]' && 
               comment.body.includes('Preview Blog')
             );
-
+            
             for (const comment of previewComments) {
               await github.rest.issues.deleteComment({
                 owner: context.repo.owner,
@@ -115,11 +118,11 @@ jobs:
             const branch = context.payload.pull_request.head.ref;
             const owner = context.payload.pull_request.head.repo.owner.login;
             const repo = context.payload.pull_request.head.repo.name;
-
+            
             const blogListUrl = `https://www.binapani.com/draft/blog?preview=${branch}&owner=${owner}&repo=${repo}`;
-
+            
             let body = `## 👀 Preview Blog\n\n${message}\n\n`;
-
+            
             if (!slugs[0]) {
               body += `🔍 Please check the [guidelines](https://github.com/binapani-edu/blog/blob/main/README.md) for instructions on how to add your blog.\n\n`;
             } else {
@@ -134,10 +137,10 @@ jobs:
               body += `📝 Blog Content Preview: ${contentLinks}\n\n`;
               body += `These links will be updated automatically when you push new changes.\n\n`;
             }
-
+            
             body += ` ---\n\n`;
             body += `Useful Links | [Binapani Blog](https://www.binapani.com/blog) | [Binapani Blog Preview Tool](https://www.binapani.com/draft/blog)`;
-
+            
             await github.rest.issues.createComment({
               owner: context.repo.owner,
               repo: context.repo.repo,

--- a/.github/workflows/preview-link.yml
+++ b/.github/workflows/preview-link.yml
@@ -13,25 +13,51 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
+        with:
+          fetch-depth: 0  # Fetch all history for proper diff
 
       - name: Find blog slug
         id: find-slug
         run: |
-          # Get changed files
-          CHANGED_FILES=$(git diff --name-only ${{ github.event.pull_request.base.sha }} ${{ github.event.pull_request.head.sha }})
+          # Get changed files, handle potential errors
+          CHANGED_FILES=$(git diff --name-only ${{ github.event.pull_request.base.sha }} ${{ github.event.pull_request.head.sha }} 2>/dev/null || echo "")
+          
+          if [ -z "$CHANGED_FILES" ]; then
+            echo "message=No changes detected in blog content." >> $GITHUB_OUTPUT
+            exit 0
+          fi
           
           # Look for new blog folders or changes in _blog.yml
           if echo "$CHANGED_FILES" | grep -q "^blogs/.*/content.md$"; then
             # Extract folder name from changed content.md
             SLUG=$(echo "$CHANGED_FILES" | grep "^blogs/.*/content.md$" | head -n 1 | cut -d'/' -f2)
-            echo "slug=$SLUG" >> $GITHUB_OUTPUT
+            if [ -n "$SLUG" ]; then
+              echo "slug=$SLUG" >> $GITHUB_OUTPUT
+              # Check if this is a new blog or edit
+              if git ls-tree -r --name-only ${{ github.event.pull_request.base.sha }} | grep -q "^blogs/$SLUG/"; then
+                echo "message=Edit detected in blog: $SLUG" >> $GITHUB_OUTPUT
+              else
+                echo "message=New blog detected: $SLUG" >> $GITHUB_OUTPUT
+              fi
+            else
+              echo "message=No changes detected in blog content." >> $GITHUB_OUTPUT
+            fi
           elif echo "$CHANGED_FILES" | grep -q "^_blog.yml$"; then
             # If _blog.yml changed, get the last added/modified blog slug
-            SLUG=$(git diff ${{ github.event.pull_request.base.sha }} ${{ github.event.pull_request.head.sha }} _blog.yml | grep -A 5 "slug:" | grep "slug:" | tail -n 1 | cut -d'"' -f2)
-            echo "slug=$SLUG" >> $GITHUB_OUTPUT
+            SLUG=$(git diff ${{ github.event.pull_request.base.sha }} ${{ github.event.pull_request.head.sha }} _blog.yml 2>/dev/null | grep -A 5 "slug:" | grep "slug:" | tail -n 1 | cut -d'"' -f2)
+            if [ -n "$SLUG" ]; then
+              echo "slug=$SLUG" >> $GITHUB_OUTPUT
+              # Check if this is a new blog or edit
+              if git ls-tree -r --name-only ${{ github.event.pull_request.base.sha }} | grep -q "^blogs/$SLUG/"; then
+                echo "message=Edit detected in blog: $SLUG" >> $GITHUB_OUTPUT
+              else
+                echo "message=New blog detected: $SLUG" >> $GITHUB_OUTPUT
+              fi
+            else
+              echo "message=No changes detected in blog content." >> $GITHUB_OUTPUT
+            fi
           else
-            echo "No blog content changes found"
-            exit 0
+            echo "message=No changes detected in blog content." >> $GITHUB_OUTPUT
           fi
 
       - name: Delete old preview comments
@@ -46,7 +72,7 @@ jobs:
             });
             
             const previewComments = comments.filter(comment => 
-              comment.body.includes('Blog Preview Link') && 
+              comment.body.includes('Blog Preview') && 
               comment.user.login === 'github-actions[bot]'
             );
             
@@ -58,17 +84,28 @@ jobs:
               });
             }
 
-      - name: Comment preview link
+      - name: Comment preview link or status
         uses: actions/github-script@v7
-        if: steps.find-slug.outputs.slug != ''
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           script: |
+            const message = '${{ steps.find-slug.outputs.message }}';
+            const slug = '${{ steps.find-slug.outputs.slug }}';
+            
+            if (!slug) {
+              await github.rest.issues.createComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: context.issue.number,
+                body: `## Blog Preview Status\n\n${message}`
+              });
+              return;
+            }
+            
             const baseUrl = 'https://binapani.com/draft/blog';
             const branch = context.payload.pull_request.head.ref;
             const owner = context.payload.pull_request.head.repo.owner.login;
             const repo = context.payload.pull_request.head.repo.name;
-            const slug = '${{ steps.find-slug.outputs.slug }}';
             
             const previewUrl = `${baseUrl}/${slug}?preview=${branch}&owner=${owner}&repo=${repo}`;
             
@@ -76,5 +113,5 @@ jobs:
               owner: context.repo.owner,
               repo: context.repo.repo,
               issue_number: context.issue.number,
-              body: `## Blog Preview Link\n\nYou can preview your blog post here:\n\n${previewUrl}\n\nThis link will be updated automatically when you push new changes.`
+              body: `## Blog Preview Link\n\n${message}\n\nYou can preview your blog post here:\n\n${previewUrl}\n\nThis link will be updated automatically when you push new changes.`
             }); 

--- a/.github/workflows/preview-link.yml
+++ b/.github/workflows/preview-link.yml
@@ -16,33 +16,27 @@ jobs:
         with:
           fetch-depth: 0
 
+      - name: Install yq
+        run: |
+          sudo wget -qO /usr/local/bin/yq https://github.com/mikefarah/yq/releases/latest/download/yq_linux_amd64
+          sudo chmod +x /usr/local/bin/yq
+
       - name: Detect blog changes
         id: detect-changes
         run: |
           # Get list of slugs from main branch _blog.yml
-          git show ${{ github.event.pull_request.base.sha }}:_blog.yml > main_blog.yml 2>/dev/null || echo "" > main_blog.yml
+          git show ${{ github.event.pull_request.base.sha }}:_blog.yml > main_blog.yml 2>/dev/null || echo "[]" > main_blog.yml
           
-          # Extract all slugs from main branch
-          MAIN_SLUGS=()
-          while IFS= read -r line; do
-            if [[ $line =~ ^[[:space:]]*-[[:space:]]*slug:[[:space:]]*[\"']?([^\"']+)[\"']?$ ]]; then
-              MAIN_SLUGS+=("${BASH_REMATCH[1]}")
-            fi
-          done < main_blog.yml
+          # Extract all slugs from main branch using yq
+          MAIN_SLUGS=$(yq e '.[].slug' main_blog.yml | sort) || MAIN_SLUGS=""
           
           # Extract all slugs from current _blog.yml
-          CURRENT_SLUGS=()
-          while IFS= read -r line; do
-            if [[ $line =~ ^[[:space:]]*-[[:space:]]*slug:[[:space:]]*[\"']?([^\"']+)[\"']?$ ]]; then
-              CURRENT_SLUGS+=("${BASH_REMATCH[1]}")
-            fi
-          done < _blog.yml
+          CURRENT_SLUGS=$(yq e '.[].slug' _blog.yml | sort) || CURRENT_SLUGS=""
           
-          # Find new and edited slugs
+          # Find new slugs (those in current but not in main)
           NEW_SLUGS=()
-          
-          for slug in "${CURRENT_SLUGS[@]}"; do
-            if ! echo "${MAIN_SLUGS[@]}" | grep -q "$slug"; then
+          for slug in $CURRENT_SLUGS; do
+            if ! echo "$MAIN_SLUGS" | grep -q "^$slug$"; then
               NEW_SLUGS+=("$slug")
             fi
           done
@@ -53,36 +47,31 @@ jobs:
           # Get changed files
           CHANGED_FILES=$(git diff --name-only ${{ github.event.pull_request.base.sha }} ${{ github.event.pull_request.head.sha }})
           
-          for slug in "${CURRENT_SLUGS[@]}"; do
+          # For each slug in current but not new, check if it was edited
+          for slug in $CURRENT_SLUGS; do
             # Skip if it's a new slug
-            if echo "${NEW_SLUGS[@]}" | grep -q "$slug"; then
+            if [[ " ${NEW_SLUGS[@]} " =~ " ${slug} " ]]; then
               continue
             fi
             
-            # Check if content.md was changed
+            # Check if blog files were changed
             if echo "$CHANGED_FILES" | grep -q "^blogs/$slug/"; then
               EDITED_SLUGS+=("$slug")
+              continue
             fi
-          done
-          
-          # Also check if _blog.yml was modified for existing slugs
-          if echo "$CHANGED_FILES" | grep -q "^_blog.yml$"; then
-            for slug in "${CURRENT_SLUGS[@]}"; do
-              # Skip if it's already in NEW_SLUGS or EDITED_SLUGS
-              if echo "${NEW_SLUGS[@]}" | grep -q "$slug" || echo "${EDITED_SLUGS[@]}" | grep -q "$slug"; then
-                continue
-              fi
+            
+            # Check if this slug's entry in _blog.yml was modified
+            if echo "$CHANGED_FILES" | grep -q "^_blog.yml$"; then
+              # Get the yaml block for this slug from both versions
+              MAIN_ENTRY=$(git show ${{ github.event.pull_request.base.sha }}:_blog.yml | yq e ".[] | select(.slug == \"$slug\")" - 2>/dev/null) || MAIN_ENTRY=""
+              CURRENT_ENTRY=$(yq e ".[] | select(.slug == \"$slug\")" _blog.yml 2>/dev/null) || CURRENT_ENTRY=""
               
-              # Check if this slug entry was modified in _blog.yml
-              if git diff ${{ github.event.pull_request.base.sha }} ${{ github.event.pull_request.head.sha }} _blog.yml | grep -q "slug: $slug"; then
+              # If they differ, mark as edited
+              if [ "$MAIN_ENTRY" != "$CURRENT_ENTRY" ]; then
                 EDITED_SLUGS+=("$slug")
               fi
-            done
-          fi
-          
-          # Remove duplicates
-          NEW_SLUGS=($(echo "${NEW_SLUGS[@]}" | tr ' ' '\n' | sort -u | tr '\n' ' '))
-          EDITED_SLUGS=($(echo "${EDITED_SLUGS[@]}" | tr ' ' '\n' | sort -u | tr '\n' ' '))
+            fi
+          done
           
           # Format slugs for output
           if [ ${#NEW_SLUGS[@]} -gt 0 ]; then

--- a/.github/workflows/preview-link.yml
+++ b/.github/workflows/preview-link.yml
@@ -1,4 +1,4 @@
-name: Blog Preview Link Commenter
+name: Blog Preview Link
 
 on:
   pull_request:
@@ -21,16 +21,16 @@ jobs:
         run: |
           # Get changed files, handle potential errors
           CHANGED_FILES=$(git diff --name-only ${{ github.event.pull_request.base.sha }} ${{ github.event.pull_request.head.sha }} 2>/dev/null || echo "")
-          
+
           if [ -z "$CHANGED_FILES" ]; then
             echo "message=No blog content changes detected!" >> $GITHUB_OUTPUT
             exit 0
           fi
-          
+
           # Initialize arrays for new and edited blogs
           NEW_BLOGS=()
           EDITED_BLOGS=()
-          
+
           # Look for changes in blog folders
           while IFS= read -r file; do
             if [[ $file =~ ^blogs/([^/]+)/content\.md$ ]]; then
@@ -42,7 +42,7 @@ jobs:
               fi
             fi
           done <<< "$CHANGED_FILES"
-          
+
           # Look for changes in _blog.yml
           if echo "$CHANGED_FILES" | grep -q "^_blog.yml$"; then
             # Get all slugs from _blog.yml changes
@@ -56,11 +56,11 @@ jobs:
               fi
             done < <(git diff ${{ github.event.pull_request.base.sha }} ${{ github.event.pull_request.head.sha }} _blog.yml 2>/dev/null | grep -A 5 "slug:" | grep "slug:" | cut -d'"' -f2)
           fi
-          
+
           # Remove duplicates and sort
           NEW_BLOGS=($(printf "%s\n" "${NEW_BLOGS[@]}" | sort -u))
           EDITED_BLOGS=($(printf "%s\n" "${EDITED_BLOGS[@]}" | sort -u))
-          
+
           # Prepare message based on changes
           if [ ${#NEW_BLOGS[@]} -gt 0 ] && [ ${#EDITED_BLOGS[@]} -gt 0 ]; then
             # Join arrays with comma and space
@@ -90,13 +90,13 @@ jobs:
               repo: context.repo.repo,
               issue_number: context.issue.number,
             });
-            
+
             // Delete all comments from the bot that contain "Preview Blog"
             const previewComments = comments.filter(comment => 
               comment.user.login === 'github-actions[bot]' && 
               comment.body.includes('Preview Blog')
             );
-            
+
             for (const comment of previewComments) {
               await github.rest.issues.deleteComment({
                 owner: context.repo.owner,
@@ -115,11 +115,11 @@ jobs:
             const branch = context.payload.pull_request.head.ref;
             const owner = context.payload.pull_request.head.repo.owner.login;
             const repo = context.payload.pull_request.head.repo.name;
-            
+
             const blogListUrl = `https://www.binapani.com/draft/blog?preview=${branch}&owner=${owner}&repo=${repo}`;
-            
+
             let body = `## 👀 Preview Blog\n\n${message}\n\n`;
-            
+
             if (!slugs[0]) {
               body += `🔍 Please check the [guidelines](https://github.com/binapani-edu/blog/blob/main/README.md) for instructions on how to add your blog.\n\n`;
             } else {
@@ -134,10 +134,10 @@ jobs:
               body += `📝 Blog Content Preview: ${contentLinks}\n\n`;
               body += `These links will be updated automatically when you push new changes.\n\n`;
             }
-            
+
             body += ` ---\n\n`;
             body += `Useful Links | [Binapani Blog](https://www.binapani.com/blog) | [Binapani Blog Preview Tool](https://www.binapani.com/draft/blog)`;
-            
+
             await github.rest.issues.createComment({
               owner: context.repo.owner,
               repo: context.repo.repo,

--- a/.github/workflows/preview-link.yml
+++ b/.github/workflows/preview-link.yml
@@ -86,16 +86,16 @@ jobs:
           
           # Determine message based on changes
           if [ ${#NEW_SLUGS[@]} -gt 0 ] && [ ${#EDITED_SLUGS[@]} -gt 0 ]; then
-            echo "message=Multiple changes detected:\n\nNew blogs: ${NEW_SLUGS_STR}\n\nEdits in: ${EDITED_SLUGS_STR}" >> $GITHUB_OUTPUT
+            echo "message=👀 Multiple changes detected:\n\n🟢 New blogs: ${NEW_SLUGS_STR}\n🟠 Edits in: ${EDITED_SLUGS_STR}" >> $GITHUB_OUTPUT
             echo "has_changes=true" >> $GITHUB_OUTPUT
           elif [ ${#NEW_SLUGS[@]} -gt 0 ]; then
-            echo "message=New blogs detected: ${NEW_SLUGS_STR}" >> $GITHUB_OUTPUT
+            echo "message=🟢 New blogs detected: ${NEW_SLUGS_STR}" >> $GITHUB_OUTPUT
             echo "has_changes=true" >> $GITHUB_OUTPUT
           elif [ ${#EDITED_SLUGS[@]} -gt 0 ]; then
-            echo "message=Edits in existing blogs detected: ${EDITED_SLUGS_STR}" >> $GITHUB_OUTPUT
+            echo "message=🟠 Edits in existing blogs detected: ${EDITED_SLUGS_STR}" >> $GITHUB_OUTPUT
             echo "has_changes=true" >> $GITHUB_OUTPUT
           else
-            echo "message=No blog content changes detected!" >> $GITHUB_OUTPUT
+            echo "message=⚪ No blog content changes detected!" >> $GITHUB_OUTPUT
             echo "has_changes=false" >> $GITHUB_OUTPUT
           fi
 
@@ -135,12 +135,12 @@ jobs:
             const owner = context.payload.pull_request.head.repo.owner.login;
             const repo = context.payload.pull_request.head.repo.name;
             
-            let body = `## 👀 Preview Blog\n\n${message}\n\n`;
+            let body = `## Preview Blog\n\n${message}\n\n`;
             
             if (hasChanges) {
               const blogListUrl = `https://www.binapani.com/draft/blog?preview=${branch}&owner=${owner}&repo=${repo}`;
-              body += `## 🔍 Preview Links\n\n`;
-              body += `📚 [Blog List Preview](${blogListUrl}) - your blog card in the list of all blogs\n`;
+              body += `## Preview Links\n\n`;
+              body += `📚 See your blog listings: [Blog List Preview](${blogListUrl})\n`;
               
               // Create content preview links for each blog
               let slugs = [];
@@ -160,7 +160,7 @@ jobs:
                   `[${slug}](${`https://www.binapani.com/draft/blog/${slug}?preview=${branch}&owner=${owner}&repo=${repo}`})`
                 ).join(', ');
                 
-                body += `📝 Blog Content Preview: ${contentLinks}\n\n`;
+                body += `📝 See your blog content: ${contentLinks}\n\n`;
               }
               
               body += `These links will be updated automatically when you push new changes.\n\n`;
@@ -168,8 +168,9 @@ jobs:
               body += `🔍 Please check the [guidelines](https://github.com/binapani-edu/blog/blob/main/README.md) for instructions on how to add your blog.\n\n`;
             }
             
-            body += ` ---\n\n`;
-            body += `Useful Links | [Binapani Blog](https://www.binapani.com/blog) | [Binapani Blog Preview Tool](https://www.binapani.com/draft/blog)`;
+            body += `## Useful Links\n\n`;
+            body += `- Published Blogs: [Binapani Blog](https://www.binapani.com/blog)\n`;
+            body += `- Review Drafts: [Binapani Blog Preview Tool](https://www.binapani.com/draft/blog)\n`;
             
             await github.rest.issues.createComment({
               owner: context.repo.owner,


### PR DESCRIPTION
closes #5, #7

## Description

<details>

<summary>workflow logic</summary>

## Core Logic:

1. **Simple Change Detection:**
   - Extracts slugs from main branch's `_blog.yml`
   - Extracts slugs from current PR's `_blog.yml`
   - Compares the two to find new blogs
   - Checks for changes in existing blog folders/entries

2. **Clean Classification:**
   - **New Blogs:** Any slug in current `_blog.yml` that doesn't exist in main
   - **Edited Blogs:** 
     - Existing slugs with changes in their blog folder
     - Existing slugs with changes to their entry in `_blog.yml`

The workflow now:
1. Gets slugs from both main and PR branches
2. Compares them to find new and edited blogs
3. Checks for content changes in existing blogs
4. Formats and outputs appropriate messages
5. Generates preview links for relevant blogs

</details>

## Testing

<details>

<summary>screenshots captured while testing</summary>

![image](https://github.com/user-attachments/assets/483de1af-626f-437b-b3a8-f1cf9a263dca)

![image](https://github.com/user-attachments/assets/982b829b-d252-4afd-b33f-87356f1d7259)

![image](https://github.com/user-attachments/assets/4fa98fe6-4812-43dc-97ea-c81815b2b695)

</details>